### PR TITLE
Implement shadow crafter block with ghost items

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,9 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+        modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+        modImplementation "net.fabricmc.fabric-api:fabric-command-api-v2:${project.fabric_version}"
+        modImplementation "net.fabricmc.fabric-api:fabric-screen-handler-api-v1:${project.fabric_version}"
 	
 }
 

--- a/src/main/java/com/example/shadow/ShadowMod.java
+++ b/src/main/java/com/example/shadow/ShadowMod.java
@@ -1,0 +1,45 @@
+package com.example.shadow;
+
+import com.example.shadow.block.ShadowCrafterBlock;
+import com.example.shadow.block.ShadowCrafterBlockEntity;
+import com.example.shadow.command.ShadowCommand;
+import com.example.shadow.screen.ShadowCrafterScreenHandler;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
+import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry;
+import net.minecraft.block.Block;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.util.Identifier;
+
+public class ShadowMod implements ModInitializer {
+    public static final String MOD_ID = "modid";
+
+    public static Block SHADOW_CRAFTER_BLOCK;
+    public static BlockEntityType<ShadowCrafterBlockEntity> SHADOW_CRAFTER_BE;
+    public static ScreenHandlerType<ShadowCrafterScreenHandler> SHADOW_CRAFTER_HANDLER;
+
+    @Override
+    public void onInitialize() {
+        SHADOW_CRAFTER_BLOCK = Registry.register(Registries.BLOCK,
+                new Identifier(MOD_ID, "shadow_crafter"),
+                new ShadowCrafterBlock(Block.Settings.create()));
+
+        Registry.register(Registries.ITEM, new Identifier(MOD_ID, "shadow_crafter"),
+                new BlockItem(SHADOW_CRAFTER_BLOCK, new Item.Settings()));
+
+        SHADOW_CRAFTER_BE = Registry.register(Registries.BLOCK_ENTITY_TYPE,
+                new Identifier(MOD_ID, "shadow_crafter"),
+                FabricBlockEntityTypeBuilder.create(ShadowCrafterBlockEntity::new, SHADOW_CRAFTER_BLOCK).build());
+
+        SHADOW_CRAFTER_HANDLER = ScreenHandlerRegistry.registerSimple(
+                new Identifier(MOD_ID, "shadow_crafter"),
+                ShadowCrafterScreenHandler::new);
+
+        ShadowCommand.register();
+    }
+}

--- a/src/main/java/com/example/shadow/block/ShadowCrafterBlock.java
+++ b/src/main/java/com/example/shadow/block/ShadowCrafterBlock.java
@@ -1,0 +1,33 @@
+package com.example.shadow.block;
+
+import com.example.shadow.block.ShadowCrafterBlockEntity;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.BlockWithEntity;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class ShadowCrafterBlock extends BlockWithEntity {
+    public ShadowCrafterBlock(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
+        return new ShadowCrafterBlockEntity(pos, state);
+    }
+
+    @Override
+    public ActionResult onUse(BlockState state, World world, BlockPos pos,
+                              PlayerEntity player, Hand hand, BlockHitResult hit) {
+        if (!world.isClient) {
+            player.openHandledScreen((NamedScreenHandlerFactory) world.getBlockEntity(pos));
+        }
+        return ActionResult.SUCCESS;
+    }
+}

--- a/src/main/java/com/example/shadow/block/ShadowCrafterBlockEntity.java
+++ b/src/main/java/com/example/shadow/block/ShadowCrafterBlockEntity.java
@@ -1,0 +1,115 @@
+package com.example.shadow.block;
+
+import com.example.shadow.ShadowMod;
+import com.example.shadow.screen.ShadowCrafterScreenHandler;
+import com.example.shadow.util.ShadowItem;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
+import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.text.Text;
+import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.List;
+
+public class ShadowCrafterBlockEntity extends BlockEntity implements NamedScreenHandlerFactory, Inventory {
+    private final DefaultedList<ShadowItem> ghostSlots = DefaultedList.ofSize(9, ShadowItem.EMPTY);
+
+    public ShadowCrafterBlockEntity(BlockPos pos, BlockState state) {
+        super(ShadowMod.SHADOW_CRAFTER_BE, pos, state);
+    }
+
+    // ---------- serialization ----------
+    @Override
+    public void writeNbt(NbtCompound nbt) {
+        NbtList list = new NbtList();
+        for (ShadowItem si : ghostSlots) list.add(si.writeNbt());
+        nbt.put("Ghosts", list);
+    }
+
+    @Override
+    public void readNbt(NbtCompound nbt) {
+        NbtList list = nbt.getList("Ghosts", NbtElement.COMPOUND_TYPE);
+        for (int i = 0; i < ghostSlots.size(); i++)
+            ghostSlots.set(i, ShadowItem.readNbt(list.getCompound(i)));
+    }
+
+    // ---------- GUI ----------
+    @Override
+    public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
+        return new ShadowCrafterScreenHandler(syncId, inv, this);
+    }
+
+    @Override
+    public Text getDisplayName() {
+        return Text.translatable("block.shadow.crafter");
+    }
+
+    // ---------- public API for command ----------
+    public void setGhost(int slot, ItemStack stack) {
+        ghostSlots.set(slot, ShadowItem.of(stack));
+        markDirty();
+        if (getWorld() != null)
+            getWorld().updateListeners(getPos(), getCachedState(), getCachedState(), 3);
+    }
+
+    public void clearGhosts() {
+        for (int i = 0; i < ghostSlots.size(); i++) ghostSlots.set(i, ShadowItem.EMPTY);
+        markDirty();
+        if (getWorld() != null)
+            getWorld().updateListeners(getPos(), getCachedState(), getCachedState(), 3);
+    }
+
+    public List<ShadowItem> ghosts() { return ghostSlots; }
+
+    // ---------- Inventory impl for GhostSlot ----------
+    @Override
+    public int size() { return ghostSlots.size(); }
+
+    @Override
+    public boolean isEmpty() {
+        for (ShadowItem s : ghostSlots) if (s != ShadowItem.EMPTY) return false;
+        return true;
+    }
+
+    @Override
+    public ItemStack getStack(int slot) {
+        ShadowItem si = ghostSlots.get(slot);
+        if (si == ShadowItem.EMPTY) return ItemStack.EMPTY;
+        ItemStack stack = new ItemStack(si.item().value());
+        stack.setCount(si.count());
+        return stack;
+    }
+
+    @Override
+    public ItemStack removeStack(int slot, int amount) { return ItemStack.EMPTY; }
+
+    @Override
+    public ItemStack removeStack(int slot) { return ItemStack.EMPTY; }
+
+    @Override
+    public void setStack(int slot, ItemStack stack) {
+        setGhost(slot, stack);
+    }
+
+    @Override
+    public void markDirty() {
+        super.markDirty();
+    }
+
+    @Override
+    public boolean canPlayerUse(PlayerEntity player) { return true; }
+
+    @Override
+    public void clear() {
+        clearGhosts();
+    }
+}

--- a/src/main/java/com/example/shadow/command/ShadowCommand.java
+++ b/src/main/java/com/example/shadow/command/ShadowCommand.java
@@ -1,0 +1,48 @@
+package com.example.shadow.command;
+
+import com.example.shadow.block.ShadowCrafterBlockEntity;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.hit.BlockHitResult;
+
+import static net.minecraft.server.command.CommandManager.literal;
+
+public class ShadowCommand {
+    public static void register() {
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, env) ->
+                dispatcher.register(literal("item-shadow")
+                        .requires(src -> src.hasPermissionLevel(2))
+                        .then(literal("set").executes(ctx -> setGhost(ctx.getSource())))
+                        .then(literal("clear").executes(ctx -> clearGhost(ctx.getSource())))
+                        .then(literal("dump").executes(ctx -> dumpGhost(ctx.getSource())))));
+    }
+
+    private static ShadowCrafterBlockEntity targetBlock(ServerPlayerEntity player) throws CommandSyntaxException {
+        BlockHitResult hit = (BlockHitResult) player.raycast(5, 0, false);
+        ShadowCrafterBlockEntity be = (ShadowCrafterBlockEntity) player.getWorld().getBlockEntity(hit.getBlockPos());
+        if (be != null) return be;
+        throw new com.mojang.brigadier.exceptions.SimpleCommandExceptionType(Text.literal("No Shadow Crafter in sight")).create();
+    }
+
+    private static int setGhost(ServerCommandSource src) throws CommandSyntaxException {
+        ServerPlayerEntity player = src.getPlayer();
+        targetBlock(player).setGhost(0, player.getMainHandStack());
+        src.sendFeedback(() -> Text.literal("Set ghost"), false);
+        return 1;
+    }
+    private static int clearGhost(ServerCommandSource src) throws CommandSyntaxException {
+        targetBlock(src.getPlayer()).clearGhosts();
+        src.sendFeedback(() -> Text.literal("Ghosts cleared"), false);
+        return 1;
+    }
+    private static int dumpGhost(ServerCommandSource src) throws CommandSyntaxException {
+        ShadowCrafterBlockEntity be = targetBlock(src.getPlayer());
+        for (int i = 0; i < be.ghosts().size(); i++) {
+            src.sendFeedback(() -> Text.literal(i + ": " + be.ghosts().get(i).toString()), false);
+        }
+        return 1;
+    }
+}

--- a/src/main/java/com/example/shadow/screen/ShadowCrafterScreenHandler.java
+++ b/src/main/java/com/example/shadow/screen/ShadowCrafterScreenHandler.java
@@ -1,0 +1,27 @@
+package com.example.shadow.screen;
+
+import com.example.shadow.block.ShadowCrafterBlockEntity;
+import com.example.shadow.util.GhostSlot;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.PropertyDelegate;
+import net.minecraft.screen.ScreenHandler;
+
+public class ShadowCrafterScreenHandler extends ScreenHandler {
+    public final PropertyDelegate delegate;
+    private final ShadowCrafterBlockEntity be;
+
+    public ShadowCrafterScreenHandler(int syncId, PlayerInventory inv, ShadowCrafterBlockEntity be) {
+        super(com.example.shadow.ShadowMod.SHADOW_CRAFTER_HANDLER, syncId);
+        this.be = be;
+        this.delegate = new net.minecraft.screen.ArrayPropertyDelegate(1);
+        for (int i = 0; i < 9; ++i) {
+            this.addSlot(new GhostSlot(be, i, 8 + i * 18, 20));
+        }
+    }
+
+    @Override
+    public boolean canUse(PlayerEntity player) {
+        return true;
+    }
+}

--- a/src/main/java/com/example/shadow/util/GhostSlot.java
+++ b/src/main/java/com/example/shadow/util/GhostSlot.java
@@ -1,0 +1,22 @@
+package com.example.shadow.util;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.slot.Slot;
+
+public class GhostSlot extends Slot {
+    public GhostSlot(Inventory inv, int index, int x, int y) {
+        super(inv, index, x, y);
+    }
+
+    @Override
+    public boolean canInsert(ItemStack stack) {
+        return true;
+    }
+
+    @Override
+    public boolean canTakeItems(PlayerEntity playerEntity) {
+        return false;
+    }
+}

--- a/src/main/java/com/example/shadow/util/ShadowItem.java
+++ b/src/main/java/com/example/shadow/util/ShadowItem.java
@@ -1,0 +1,33 @@
+package com.example.shadow.util;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryEntry;
+import net.minecraft.util.Identifier;
+
+public record ShadowItem(RegistryEntry<Item> item, int nbtHash, int count) {
+    public static final ShadowItem EMPTY = new ShadowItem(null, 0, 0);
+
+    public static ShadowItem of(ItemStack stack) {
+        return new ShadowItem(
+                Registries.ITEM.getEntry(stack.getItem()),
+                stack.hasNbt() ? stack.getNbt().hashCode() : 0,
+                stack.getCount());
+    }
+
+    public NbtCompound writeNbt() {
+        NbtCompound tag = new NbtCompound();
+        if (item != null)
+            tag.putString("id", Registries.ITEM.getId(item.value()).toString());
+        if (nbtHash != 0) tag.putInt("h", nbtHash);
+        tag.putByte("c", (byte) count);
+        return tag;
+    }
+
+    public static ShadowItem readNbt(NbtCompound tag) {
+        Item i = Registries.ITEM.get(new Identifier(tag.getString("id")));
+        return new ShadowItem(i.getRegistryEntry(), tag.getInt("h"), tag.getByte("c"));
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,9 +15,9 @@
 	"icon": "assets/modid/icon.png",
 	"environment": "*",
 	"entrypoints": {
-		"main": [
-			"com.example.ExampleMod"
-		],
+                "main": [
+                        "com.example.shadow.ShadowMod"
+                ],
 		"client": [
 			"com.example.ExampleModClient"
 		]


### PR DESCRIPTION
## Summary
- implement Shadow Crafter block/entity with optimized ghost item storage
- add GhostSlot and custom screen handler
- register new command `/item-shadow`
- wire everything through new ShadowMod entrypoint
- require command and screen handler API modules

## Testing
- `./gradlew test` *(fails: No route to host while downloading Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_683ae9359364833099e2730c7ef31d19