### PR TITLE
Fix Shadow item nbt handling

### DIFF
--- a/src/main/java/com/example/shadow/block/ShadowCrafterBlockEntity.java
+++ b/src/main/java/com/example/shadow/block/ShadowCrafterBlockEntity.java
@@ -34,9 +34,13 @@ public class ShadowCrafterBlockEntity extends BlockEntity implements NamedScreen
     }
 
     public void readNbt(NbtCompound nbt) {
-        NbtList list = nbt.getList("Ghosts");
+        // Prior to 1.21 the returned value was a direct list, newer versions
+        // wrap it in an Optional. Use an empty list when the tag is missing.
+        NbtList list = nbt.getList("Ghosts").orElseGet(NbtList::new);
         for (int i = 0; i < ghostSlots.size() && i < list.size(); i++) {
-            ghostSlots.set(i, ShadowItem.readNbt(list.getCompound(i)));
+            // Newer Yarn returns Optional<NbtCompound> for typed access.
+            NbtCompound tag = list.getCompound(i).orElseGet(NbtCompound::new);
+            ghostSlots.set(i, ShadowItem.readNbt(tag));
         }
     }
 
@@ -82,7 +86,7 @@ public class ShadowCrafterBlockEntity extends BlockEntity implements NamedScreen
     public ItemStack getStack(int slot) {
         ShadowItem si = ghostSlots.get(slot);
         if (si == ShadowItem.EMPTY) return ItemStack.EMPTY;
-        ItemStack stack = new ItemStack(si.item().value());
+        ItemStack stack = new ItemStack(si.item());
         stack.setCount(si.count());
         return stack;
     }

--- a/src/main/java/com/example/shadow/util/ShadowItem.java
+++ b/src/main/java/com/example/shadow/util/ShadowItem.java
@@ -4,15 +4,14 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.Registries;
-import net.minecraft.registry.RegistryEntry;
 import net.minecraft.util.Identifier;
 
-public record ShadowItem(RegistryEntry<Item> item, int nbtHash, int count) {
+public record ShadowItem(Item item, int nbtHash, int count) {
     public static final ShadowItem EMPTY = new ShadowItem(null, 0, 0);
 
     public static ShadowItem of(ItemStack stack) {
         return new ShadowItem(
-                Registries.ITEM.getEntry(stack.getItem()),
+                stack.getItem(),
                 stack.hasNbt() ? stack.getNbt().hashCode() : 0,
                 stack.getCount());
     }
@@ -20,7 +19,7 @@ public record ShadowItem(RegistryEntry<Item> item, int nbtHash, int count) {
     public NbtCompound writeNbt() {
         NbtCompound tag = new NbtCompound();
         if (item != null)
-            tag.putString("id", Registries.ITEM.getId(item.value()).toString());
+            tag.putString("id", Registries.ITEM.getId(item).toString());
         if (nbtHash != 0) tag.putInt("h", nbtHash);
         tag.putByte("c", (byte) count);
         return tag;
@@ -28,6 +27,6 @@ public record ShadowItem(RegistryEntry<Item> item, int nbtHash, int count) {
 
     public static ShadowItem readNbt(NbtCompound tag) {
         Item i = Registries.ITEM.get(new Identifier(tag.getString("id")));
-        return new ShadowItem(i.getRegistryEntry(), tag.getInt("h"), tag.getByte("c"));
+        return new ShadowItem(i, tag.getInt("h"), tag.getByte("c"));
     }
 }


### PR DESCRIPTION
## Summary
- fix Optional `NbtList` usage in `ShadowCrafterBlockEntity`
- simplify `ShadowItem` by storing `Item` instead of `RegistryEntry`

## Testing
- `./gradlew build` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683af53199d88330af372f119e1225c4