### PR TITLE
Fix screen handler registration

### DIFF
--- a/src/main/java/com/example/shadow/ShadowMod.java
+++ b/src/main/java/com/example/shadow/ShadowMod.java
@@ -6,7 +6,6 @@ import com.example.shadow.command.ShadowCommand;
 import com.example.shadow.screen.ShadowCrafterScreenHandler;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
-import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.item.BlockItem;
@@ -36,9 +35,10 @@ public class ShadowMod implements ModInitializer {
                 new Identifier(MOD_ID, "shadow_crafter"),
                 FabricBlockEntityTypeBuilder.create(ShadowCrafterBlockEntity::new, SHADOW_CRAFTER_BLOCK).build());
 
-        SHADOW_CRAFTER_HANDLER = ScreenHandlerRegistry.registerSimple(
+        SHADOW_CRAFTER_HANDLER = Registry.register(
+                Registries.SCREEN_HANDLER,
                 new Identifier(MOD_ID, "shadow_crafter"),
-                ShadowCrafterScreenHandler::new);
+                new ScreenHandlerType<>(ShadowCrafterScreenHandler::new));
 
         ShadowCommand.register();
     }

--- a/src/main/java/com/example/shadow/command/ShadowCommand.java
+++ b/src/main/java/com/example/shadow/command/ShadowCommand.java
@@ -41,7 +41,8 @@ public class ShadowCommand {
     private static int dumpGhost(ServerCommandSource src) throws CommandSyntaxException {
         ShadowCrafterBlockEntity be = targetBlock(src.getPlayer());
         for (int i = 0; i < be.ghosts().size(); i++) {
-            src.sendFeedback(() -> Text.literal(i + ": " + be.ghosts().get(i).toString()), false);
+            final int index = i;
+            src.sendFeedback(() -> Text.literal(index + ": " + be.ghosts().get(index).toString()), false);
         }
         return 1;
     }

--- a/src/main/java/com/example/shadow/screen/ShadowCrafterScreenHandler.java
+++ b/src/main/java/com/example/shadow/screen/ShadowCrafterScreenHandler.java
@@ -4,6 +4,7 @@ import com.example.shadow.block.ShadowCrafterBlockEntity;
 import com.example.shadow.util.GhostSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.screen.PropertyDelegate;
 import net.minecraft.screen.ScreenHandler;
 
@@ -23,5 +24,10 @@ public class ShadowCrafterScreenHandler extends ScreenHandler {
     @Override
     public boolean canUse(PlayerEntity player) {
         return true;
+    }
+
+    @Override
+    public ItemStack quickMove(PlayerEntity player, int index) {
+        return ItemStack.EMPTY;
     }
 }


### PR DESCRIPTION
## Summary
- register the screen handler using `Registry.register`
- implement `quickMove` stub for `ShadowCrafterScreenHandler`
- fix variable capture in `ShadowCommand`

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683af8e481208330b8d21e40fd36bb07