### PR TITLE
Fix compile errors for newer mappings

### DIFF
--- a/src/main/java/com/example/shadow/util/ShadowItem.java
+++ b/src/main/java/com/example/shadow/util/ShadowItem.java
@@ -12,7 +12,7 @@ public record ShadowItem(Item item, int nbtHash, int count) {
     public static ShadowItem of(ItemStack stack) {
         return new ShadowItem(
                 stack.getItem(),
-                stack.hasNbt() ? stack.getNbt().hashCode() : 0,
+                0,
                 stack.getCount());
     }
 
@@ -26,7 +26,9 @@ public record ShadowItem(Item item, int nbtHash, int count) {
     }
 
     public static ShadowItem readNbt(NbtCompound tag) {
-        Item i = Registries.ITEM.get(new Identifier(tag.getString("id")));
+        String idString = tag.getString("id");
+        Identifier id = Identifier.tryParse(idString);
+        Item i = id != null ? Registries.ITEM.get(id) : null;
         return new ShadowItem(i, tag.getInt("h"), tag.getByte("c"));
     }
 }


### PR DESCRIPTION
## Summary
- stub out nbt hash calculation since ItemStack methods were removed
- parse identifiers safely using `Identifier.tryParse`

## Testing
- `gradlew build` *(fails: Gradle needs network access)*

------
https://chatgpt.com/codex/tasks/task_e_683afcd631c48330aae061345dff1cfc