### PR TITLE
Update for 1.21.5 optional NBT

### DIFF
--- a/src/main/java/com/example/shadow/ShadowMod.java
+++ b/src/main/java/com/example/shadow/ShadowMod.java
@@ -14,6 +14,7 @@ import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.util.Identifier;
+import net.minecraft.world.flag.FeatureFlags;
 
 public class ShadowMod implements ModInitializer {
     public static final String MOD_ID = "modid";
@@ -25,20 +26,20 @@ public class ShadowMod implements ModInitializer {
     @Override
     public void onInitialize() {
         SHADOW_CRAFTER_BLOCK = Registry.register(Registries.BLOCK,
-                new Identifier(MOD_ID, "shadow_crafter"),
+                Identifier.of(MOD_ID, "shadow_crafter"),
                 new ShadowCrafterBlock(Block.Settings.create()));
 
-        Registry.register(Registries.ITEM, new Identifier(MOD_ID, "shadow_crafter"),
+        Registry.register(Registries.ITEM, Identifier.of(MOD_ID, "shadow_crafter"),
                 new BlockItem(SHADOW_CRAFTER_BLOCK, new Item.Settings()));
 
         SHADOW_CRAFTER_BE = Registry.register(Registries.BLOCK_ENTITY_TYPE,
-                new Identifier(MOD_ID, "shadow_crafter"),
+                Identifier.of(MOD_ID, "shadow_crafter"),
                 FabricBlockEntityTypeBuilder.create(ShadowCrafterBlockEntity::new, SHADOW_CRAFTER_BLOCK).build());
 
         SHADOW_CRAFTER_HANDLER = Registry.register(
                 Registries.SCREEN_HANDLER,
-                new Identifier(MOD_ID, "shadow_crafter"),
-                new ScreenHandlerType<>(ShadowCrafterScreenHandler::new));
+                Identifier.of(MOD_ID, "shadow_crafter"),
+                new ScreenHandlerType<>(ShadowCrafterScreenHandler::new, FeatureFlags.VANILLA_SET));
 
         ShadowCommand.register();
     }

--- a/src/main/java/com/example/shadow/util/ShadowItem.java
+++ b/src/main/java/com/example/shadow/util/ShadowItem.java
@@ -10,9 +10,13 @@ public record ShadowItem(Item item, int nbtHash, int count) {
     public static final ShadowItem EMPTY = new ShadowItem(null, 0, 0);
 
     public static ShadowItem of(ItemStack stack) {
+        // ItemStack's NBT accessors were updated in newer Minecraft
+        // versions to return Optional values instead of nullable
+        // compounds. Query the optional and fall back to 0 when the
+        // stack has no tag.
         return new ShadowItem(
                 stack.getItem(),
-                stack.hasNbt() ? stack.getNbt().hashCode() : 0,
+                stack.getNbt().map(NbtCompound::hashCode).orElse(0),
                 stack.getCount());
     }
 
@@ -26,7 +30,8 @@ public record ShadowItem(Item item, int nbtHash, int count) {
     }
 
     public static ShadowItem readNbt(NbtCompound tag) {
-        Item i = Registries.ITEM.get(new Identifier(tag.getString("id")));
-        return new ShadowItem(i, tag.getInt("h"), tag.getByte("c"));
+        // Nbt accessors now return Optional values.
+        Item i = Registries.ITEM.get(Identifier.of(tag.getString("id").orElse("")));
+        return new ShadowItem(i, tag.getInt("h").orElse(0), tag.getByte("c"));
     }
 }


### PR DESCRIPTION
## Summary
- update `ShadowItem` to use optional NBT accessors
- adjust `ShadowMod` to new identifier factory method and screen handler constructor

## Testing
- `./gradlew build` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683afdda68248330befceb25fbf63b59